### PR TITLE
have installation command as block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ I took care of installing and configuring some packages so that you have vim, gi
 
 # Setup
 
-Install [cygwin](http://www.cygwin.com/) with wget (check wget in the installation process) then start cygwin and execute `wget --no-check-certificate https://raw.github.com/haithembelhaj/oh-my-cygwin/master/oh-my-cygwin.sh -O - | sh`
+Install [cygwin](http://www.cygwin.com/) with wget (check wget in the installation process) then start cygwin and execute 
+
+    wget --no-check-certificate https://raw.github.com/haithembelhaj/oh-my-cygwin/master/oh-my-cygwin.sh -O - | sh
 
 Et Voila!
 Your windows Terminal will look like this


### PR DESCRIPTION
It's easier to copy and paste the installation command as a code block (4 spaces indent) instead of a span code element (backticks).
