### PR TITLE
Early bailout on errors, proper vimrc setup

### DIFF
--- a/oh-my-cygwin.sh
+++ b/oh-my-cygwin.sh
@@ -1,33 +1,36 @@
 #!/bin/bash
+set -e
+
+SIMPLE_BACKUP_SUFFIX=".orig"
+APT_CYG="$(mktemp /tmp/apt-cyg.XXXXXXXX)"
 
 # install apt-cyg
-wget --no-check-certificate https://github.com/john-peterson/apt-cyg/raw/path/apt-cyg
-chmod +x apt-cyg
-mv apt-cyg /bin/apt-cyg
+wget --no-check-certificate "https://github.com/john-peterson/apt-cyg/raw/path/apt-cyg" -O "${APT_CYG}"
+chmod +x "${APT_CYG}"
 
 # install some stuff like vim and git
-apt-cyg install zsh mintty vim curl git openssh git-completion git-gui gitk
+"${APT_CYG}" install zsh mintty vim curl git openssh git-completion git-gui gitk
 
-#setting up vim
-cp /usr/share/vim/vim73/vimrc_example.vim ~/.vimrc
+# install OH MY ZSH
+git clone https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 
 # Create initial /etc/zshenv
 [[ ! -e /etc/zshenv ]] && echo export PATH=/usr/bin:\$PATH > /etc/zshenv
 
-# install OH MY ZSH
-/usr/bin/env git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
-if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]
+install --backup ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
+
+#setting up vim
+VIMRC_EXAMPLE=`find /usr/share/vim -type f -name vimrc_example.vim | head -n 1`
+if [ ! -f ~/.vimrc ] && [ -n "${VIMRC_EXAMPLE}" ]
 then
-  cp ~/.zshrc ~/.zshrc.orig;
-  rm ~/.zshrc;
+  install "${VIMRC_EXAMPLE}" ~/.vimrc
 fi
-cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
+
+# install apt-cyg
+install --backup "${APT_CYG}" /bin/apt-cyg
 
 # setting up zsh as default
 sed -i "s/$USER\:\/bin\/bash/$USER\:\/bin\/zsh/g" /etc/passwd
 
 # et voila just start it
 /usr/bin/env zsh
-
-
-


### PR DESCRIPTION
Fixed problems with hardcoded vim version.
Enabled bailout on first error. 
Moved all network related commands on top of script.
Used 'install' instead of checking file existence and making backup
Installing apt-cyg after script has finished setup.
