### PR TITLE
fix apt-cyg

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I took care of installing and configuring some packages so that you have vim, gi
 
 Install [cygwin](http://www.cygwin.com/) with wget (check wget in the installation process) then start cygwin and execute 
 
-    wget --no-check-certificate https://raw.github.com/haithembelhaj/oh-my-cygwin/master/oh-my-cygwin.sh -O - | sh
+    wget --no-check-certificate https://raw.githubusercontent.com/hsalinas-comscore/oh-my-cygwin/master/oh-my-cygwin.sh -O - | sh
 
 Et Voila!
 Your windows Terminal will look like this

--- a/oh-my-cygwin.sh
+++ b/oh-my-cygwin.sh
@@ -20,7 +20,7 @@ git clone https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 
 install --backup ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
 
-# setting up vim
+#setting up vim
 VIMRC_EXAMPLE=`find /usr/share/vim -type f -name vimrc_example.vim | head -n 1`
 if [ ! -f ~/.vimrc ] && [ -n "${VIMRC_EXAMPLE}" ]
 then
@@ -32,3 +32,6 @@ install --backup "${APT_CYG}" /bin/apt-cyg
 
 # setting zsh as the default shell
 setx SHELL /bin/zsh
+
+# et voila just start it
+/usr/bin/env zsh

--- a/oh-my-cygwin.sh
+++ b/oh-my-cygwin.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-SIMPLE_BACKUP_SUFFIX=".orig"
-APT_CYG="$(mktemp /tmp/apt-cyg.XXXXXXXX)"
-
 # install apt-cyg
+APT_CYG="$(mktemp /tmp/apt-cyg.XXXXXXXX)"
 wget --no-check-certificate "https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg" -O "${APT_CYG}"
 chmod +x "${APT_CYG}"
+install --backup "${APT_CYG}" /bin/apt-cyg
+APT_CYG=/bin/apt-cyg
 
 # install some stuff like vim and git
 "${APT_CYG}" install zsh mintty vim curl git openssh git-completion git-gui gitk
-
 
 # install OH MY ZSH
 git clone https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
@@ -26,9 +25,6 @@ if [ ! -f ~/.vimrc ] && [ -n "${VIMRC_EXAMPLE}" ]
 then
   install "${VIMRC_EXAMPLE}" ~/.vimrc
 fi
-
-# install apt-cyg
-install --backup "${APT_CYG}" /bin/apt-cyg
 
 # setting zsh as the default shell
 setx SHELL /bin/zsh

--- a/oh-my-cygwin.sh
+++ b/oh-my-cygwin.sh
@@ -5,7 +5,7 @@ SIMPLE_BACKUP_SUFFIX=".orig"
 APT_CYG="$(mktemp /tmp/apt-cyg.XXXXXXXX)"
 
 # install apt-cyg
-wget --no-check-certificate "https://github.com/john-peterson/apt-cyg/raw/path/apt-cyg" -O "${APT_CYG}"
+wget --no-check-certificate "https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg" -O "${APT_CYG}"
 chmod +x "${APT_CYG}"
 
 # install some stuff like vim and git

--- a/oh-my-cygwin.sh
+++ b/oh-my-cygwin.sh
@@ -20,7 +20,7 @@ git clone https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 
 install --backup ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
 
-#setting up vim
+# setting up vim
 VIMRC_EXAMPLE=`find /usr/share/vim -type f -name vimrc_example.vim | head -n 1`
 if [ ! -f ~/.vimrc ] && [ -n "${VIMRC_EXAMPLE}" ]
 then
@@ -30,8 +30,5 @@ fi
 # install apt-cyg
 install --backup "${APT_CYG}" /bin/apt-cyg
 
-# setting up zsh as default
-sed -i "s/$USER\:\/bin\/bash/$USER\:\/bin\/zsh/g" /etc/passwd
-
-# et voila just start it
-/usr/bin/env zsh
+# setting zsh as the default shell
+setx SHELL /bin/zsh


### PR DESCRIPTION
The current apt-cyg is an old fork that have a problem with files that are not bz2. 
See https://code.google.com/p/apt-cyg/issues/detail?id=46 for details.

current active repo is :
https://github.com/transcode-open/apt-cyg
