### PR TITLE
mkpasswd for /etc/passwd

### DIFF
--- a/oh-my-cygwin.sh
+++ b/oh-my-cygwin.sh
@@ -33,6 +33,9 @@ fi
 # install apt-cyg
 install --backup "${APT_CYG}" /bin/apt-cyg
 
+# make /etc/passwd
+mkpasswd -l -p "$(cygpath -H)" > /etc/passwd
+
 # setting up zsh as default
 sed -i "s/$USER\:\/bin\/bash/$USER\:\/bin\/zsh/g" /etc/passwd
 


### PR DESCRIPTION
It seems that `/etc/passwd` does not exist by default in cygwin.
Using `mkpasswd` to generate `/etc/passwd` 
:smile:
